### PR TITLE
Fix Issue #18

### DIFF
--- a/app/src/main/java/io/ray/hexis/presenter/AddItemOnClickListener.java
+++ b/app/src/main/java/io/ray/hexis/presenter/AddItemOnClickListener.java
@@ -16,6 +16,7 @@ import io.ray.hexis.view.abs.IQuadrantFragment;
  */
 public class AddItemOnClickListener implements FloatingActionButton.OnClickListener,
         AddItemDialogFragment.Listener {
+
   private final ViewPager pager;
   private final SqlLiteHelper sqlLiteHelper;
 
@@ -26,7 +27,7 @@ public class AddItemOnClickListener implements FloatingActionButton.OnClickListe
   public AddItemOnClickListener(ViewPager pager) {
     this.pager = pager;
     this.sqlLiteHelper = new SqlLiteHelper(pager.getContext());
-    pager.setOffscreenPageLimit(this.pager.getAdapter().getCount());
+    //pager.setOffscreenPageLimit(this.pager.getAdapter().getCount());
   }
 
   /**

--- a/app/src/main/java/io/ray/hexis/presenter/QuadrantViewAdapter.java
+++ b/app/src/main/java/io/ray/hexis/presenter/QuadrantViewAdapter.java
@@ -60,9 +60,10 @@ public class QuadrantViewAdapter extends RecyclerView.Adapter<QuadrantItemViewHo
 
   @Override
   public QuadrantItemViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    final ViewGroup nullParent = null;
     // Inflate the layout
     View view = LayoutInflater.from(parent.getContext())
-        .inflate(R.layout.view_quadrant_item, parent, false);
+        .inflate(R.layout.view_quadrant_item, nullParent);
 
     // Return a view holder
     return new QuadrantItemViewHolder(view);

--- a/app/src/main/res/layout/view_quadrant_item.xml
+++ b/app/src/main/res/layout/view_quadrant_item.xml
@@ -6,6 +6,6 @@
     <TextView
         android:id="@+id/quadrant_item_text"
         android:layout_width="match_parent"
-        android:layout_height="50dp"
+        android:layout_height="wrap_content"
         android:text="TextView"/>
 </LinearLayout>


### PR DESCRIPTION
Fixed Issue #18 (https://github.com/Austin-Ray/Hexis/issues/18). The
issue did not result from the add item code as previously suspected, but
rather from the code that inflated the ViewHolder.

The issue was due to the ViewHolder being inflated to the same size as
the RecyclerView. The additional items were there; however, since each
ViewHolder was as large as the RecyclerView the other items did not
appear to exist. If you scrolled the RecyclerView you could find the
other items.