### PR TITLE
Added automatic capitalization on dialogs

### DIFF
--- a/app/src/main/res/layout/fragment_add_item_dialog.xml
+++ b/app/src/main/res/layout/fragment_add_item_dialog.xml
@@ -23,7 +23,7 @@
         android:layout_marginRight="4dp"
         android:layout_marginTop="16dp"
         android:hint="Add Item"
-        android:inputType="text"
+        android:inputType="text|textCapSentences"
         android:paddingLeft="8dp"/>
     <RadioGroup android:id="@+id/toggleGroup"
         android:layout_width="fill_parent"


### PR DESCRIPTION
Added automatic capitalization for sentences on the Add and Edit
dialogs. This was bothering me when using the release version. It was an
oversight for that release that this commit fixes.