### PR TITLE
Fix sorting after adding new item

### DIFF
--- a/app/src/main/java/io/ray/hexis/presenter/AddItemOnClickListener.java
+++ b/app/src/main/java/io/ray/hexis/presenter/AddItemOnClickListener.java
@@ -8,7 +8,7 @@ import android.view.View;
 
 import io.ray.hexis.R;
 import io.ray.hexis.model.QuadrantItem;
-import io.ray.hexis.presenter.abs.ModifyItemListener;
+import io.ray.hexis.presenter.abs.IModifyItemListener;
 import io.ray.hexis.view.AddItemDialogFragment;
 import io.ray.hexis.view.abs.IQuadrantFragment;
 
@@ -16,7 +16,7 @@ import io.ray.hexis.view.abs.IQuadrantFragment;
  * Listener for the FloatingActionButton, and the DialogFragment is spawns.
  */
 public class AddItemOnClickListener implements FloatingActionButton.OnClickListener,
-    ModifyItemListener {
+    IModifyItemListener {
 
   private final ViewPager pager;
 

--- a/app/src/main/java/io/ray/hexis/presenter/QuadrantPresenter.java
+++ b/app/src/main/java/io/ray/hexis/presenter/QuadrantPresenter.java
@@ -4,8 +4,10 @@ import io.ray.hexis.model.QuadrantItem;
 import io.ray.hexis.model.abs.IQuadrantModel;
 import io.ray.hexis.presenter.abs.IMatrixPresenter;
 import io.ray.hexis.presenter.abs.IQuadrantPresenter;
+import io.ray.hexis.util.QuadrantItemComparator;
 import io.ray.hexis.view.abs.IQuadrantFragment;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -46,7 +48,8 @@ public class QuadrantPresenter implements IQuadrantPresenter {
    */
   @Override
   public void addItem(String message) {
-    matrixPresenter.addItem(quadrant, new QuadrantItem(message));
+    QuadrantItem newItem = new QuadrantItem(message);
+    matrixPresenter.addItem(quadrant, newItem);
     // Update the fragment if data set has been changed
     updateFragment();
   }
@@ -60,6 +63,7 @@ public class QuadrantPresenter implements IQuadrantPresenter {
    */
   @Override
   public void updateFragment() {
+    Collections.sort(model.getData(), new QuadrantItemComparator());
     fragment.setData(model.getData());
   }
 

--- a/app/src/main/java/io/ray/hexis/presenter/QuadrantViewAdapter.java
+++ b/app/src/main/java/io/ray/hexis/presenter/QuadrantViewAdapter.java
@@ -8,9 +8,11 @@ import android.view.ViewGroup;
 
 import io.ray.hexis.R;
 import io.ray.hexis.model.QuadrantItem;
+import io.ray.hexis.util.QuadrantItemComparator;
 import io.ray.hexis.view.QuadrantItemViewHolder;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -108,6 +110,7 @@ public class QuadrantViewAdapter extends RecyclerView.Adapter<QuadrantItemViewHo
    */
   public void setData(List<QuadrantItem> data) {
     this.data = new ArrayList<>(data);
+    Collections.sort(data, new QuadrantItemComparator());
     notifyDataSetChanged();
   }
 

--- a/app/src/main/java/io/ray/hexis/presenter/abs/IModifyItemListener.java
+++ b/app/src/main/java/io/ray/hexis/presenter/abs/IModifyItemListener.java
@@ -2,7 +2,7 @@ package io.ray.hexis.presenter.abs;
 
 import io.ray.hexis.model.QuadrantItem;
 
-public interface ModifyItemListener {
+public interface IModifyItemListener {
 
   /**
    * Add a QuadrantItem to the current fragment.

--- a/app/src/main/java/io/ray/hexis/util/QuadrantItemComparator.kt
+++ b/app/src/main/java/io/ray/hexis/util/QuadrantItemComparator.kt
@@ -1,0 +1,15 @@
+package io.ray.hexis.util
+
+import io.ray.hexis.model.QuadrantItem
+
+class QuadrantItemComparator : Comparator<QuadrantItem> {
+    override fun compare(o1: QuadrantItem?, o2: QuadrantItem?): Int {
+        if (o1?.isComplete as Boolean && !(o2?.isComplete as Boolean)) {
+           return 1
+        } else if (!o1.isComplete && o2?.isComplete as Boolean) {
+            return -1
+        }
+
+        return 0
+    }
+}

--- a/app/src/main/java/io/ray/hexis/view/AddItemDialogFragment.java
+++ b/app/src/main/java/io/ray/hexis/view/AddItemDialogFragment.java
@@ -7,7 +7,7 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.view.View;
 
-import io.ray.hexis.presenter.abs.ModifyItemListener;
+import io.ray.hexis.presenter.abs.IModifyItemListener;
 
 /**
  * DialogFragment that appears when a user adds an item to a QuadrantFragment.
@@ -20,7 +20,7 @@ public class AddItemDialogFragment extends ModifyItemDialogFragment
    * @param listener Listener for passing back the information to create a QuadrantItem
    * @return New AddItemDialogFragment instance
    */
-  public static DialogFragment newInstance(ModifyItemListener listener, String title) {
+  public static DialogFragment newInstance(IModifyItemListener listener, String title) {
     DialogFragment dialog = new AddItemDialogFragment();
 
     // Set the listener

--- a/app/src/main/java/io/ray/hexis/view/EditItemDialogFragment.java
+++ b/app/src/main/java/io/ray/hexis/view/EditItemDialogFragment.java
@@ -7,7 +7,7 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 
 import io.ray.hexis.model.QuadrantItem;
-import io.ray.hexis.presenter.abs.ModifyItemListener;
+import io.ray.hexis.presenter.abs.IModifyItemListener;
 
 /**
  * DialogFragment that appears when a user edits an item in a QuadrantFragment.
@@ -20,7 +20,7 @@ public class EditItemDialogFragment extends ModifyItemDialogFragment {
    * @param listener    Listener for passing back the information to update item in QuadrantItem
    * @return            New EditItemDialogFragment instance
    */
-  public static DialogFragment newInstance(QuadrantItem item, ModifyItemListener listener,
+  public static DialogFragment newInstance(QuadrantItem item, IModifyItemListener listener,
                                            String title) {
 
     // Initialize new EditItemDialogFragment fragment

--- a/app/src/main/java/io/ray/hexis/view/ModifyItemDialogFragment.java
+++ b/app/src/main/java/io/ray/hexis/view/ModifyItemDialogFragment.java
@@ -16,7 +16,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.ray.hexis.R;
 import io.ray.hexis.model.QuadrantItem;
-import io.ray.hexis.presenter.abs.ModifyItemListener;
+import io.ray.hexis.presenter.abs.IModifyItemListener;
 
 public class ModifyItemDialogFragment extends DialogFragment
     implements View.OnClickListener {
@@ -24,7 +24,7 @@ public class ModifyItemDialogFragment extends DialogFragment
   int selectedQuadrant;
   private String title;
 
-  ModifyItemListener listener;
+  IModifyItemListener listener;
 
   @BindView(R.id.add_item) EditText inputTextView;
   @BindView(R.id.btn_QI) ToggleButton quadOne;
@@ -103,7 +103,7 @@ public class ModifyItemDialogFragment extends DialogFragment
    *
    * @param listener Listener reference for the DialogFragment
    */
-  public void setListener(ModifyItemListener listener) {
+  public void setListener(IModifyItemListener listener) {
     this.listener = listener;
   }
 
@@ -112,7 +112,7 @@ public class ModifyItemDialogFragment extends DialogFragment
    *
    * @return Listener
    */
-  public ModifyItemListener getListener() {
+  public IModifyItemListener getListener() {
     return listener;
   }
 

--- a/app/src/test/java/io/ray/hexis/util/QuadrantItemComparatorTest.kt
+++ b/app/src/test/java/io/ray/hexis/util/QuadrantItemComparatorTest.kt
@@ -1,0 +1,23 @@
+package io.ray.hexis.util
+
+import io.ray.hexis.model.QuadrantItem
+import org.junit.Test
+
+import org.junit.Assert.*
+
+class QuadrantItemComparatorTest {
+  @Test
+  fun compare() {
+    val item1 : QuadrantItem = QuadrantItem("TEST1")
+    val item2 : QuadrantItem = QuadrantItem("TEST2")
+    val item3 : QuadrantItem = QuadrantItem("TEST3")
+
+    item3.setCompletion(true)
+
+    val comparator : QuadrantItemComparator = QuadrantItemComparator()
+
+    assertEquals(0, comparator.compare(item1, item2))
+    assertEquals(1, comparator.compare(item3, item1))
+    assertEquals(-1, comparator.compare(item1, item3))
+  }
+}


### PR DESCRIPTION
Implemented a fix to how items are sorted when a new one is added. The
current behavior will put the new items after items that have been
completed. The intended behavior of the quadrant was to put
non-completed items ahead of completed items.